### PR TITLE
Add constructive struct modifier to 3rd generation(for lin

### DIFF
--- a/grammars/UCLexer.g4
+++ b/grammars/UCLexer.g4
@@ -247,6 +247,7 @@ KW_ATOMIC: 'atomic';
 KW_ATOMICWHENCOOKED: 'atomicwhencooked';
 KW_IMMUTABLE: 'immutable';
 KW_IMMUTABLEWHENCOOKED: 'immutablewhencooked';
+KM_CONSTRUCTIVE: 'constructive';
 KW_VIRTUAL: 'virtual';
 KW_SERVER: 'server';
 KW_CLIENT: 'client';

--- a/grammars/UCParser.g4
+++ b/grammars/UCParser.g4
@@ -216,6 +216,7 @@ identifier
 	| 'atomicwhencooked'
 	| 'immutable'
 	| 'immutablewhencooked'
+    | 'constructive'
 	| 'virtual'
 	| 'server'
 	| 'client'
@@ -502,6 +503,7 @@ structModifier
 	| { this.generation === 3 }? 'atomicwhencooked'
 	| { this.generation === 3 }? 'immutable'
 	| { this.generation === 3 }? 'immutablewhencooked'
+    | { this.generation === 3 }? 'constructive'
 	;
 
 arrayDimRefer

--- a/grammars/UCParser.g4
+++ b/grammars/UCParser.g4
@@ -216,7 +216,7 @@ identifier
 	| 'atomicwhencooked'
 	| 'immutable'
 	| 'immutablewhencooked'
-    | 'constructive'
+	| 'constructive'
 	| 'virtual'
 	| 'server'
 	| 'client'
@@ -503,7 +503,7 @@ structModifier
 	| { this.generation === 3 }? 'atomicwhencooked'
 	| { this.generation === 3 }? 'immutable'
 	| { this.generation === 3 }? 'immutablewhencooked'
-    | { this.generation === 3 }? 'constructive'
+	| { this.generation === 3 }? 'constructive'
 	;
 
 arrayDimRefer

--- a/syntaxes/UnrealScript.YAML-tmLanguage
+++ b/syntaxes/UnrealScript.YAML-tmLanguage
@@ -694,7 +694,7 @@ repository:
     patterns:
       - include: '#comment'
 
-      - match: \b((?i)native|intrinsic|transient|export|strictconfig|atomic|atomicwhencooked|immutable|immutablewhencooked|init|long)\b
+      - match: \b((?i)native|intrinsic|transient|export|strictconfig|atomic|atomicwhencooked|immutable|immutablewhencooked|constructive|init|long)\b
         name: storage.modifier.uc
 
       - match: \b((?i)extends|expands)\b(?:\s+(\w+)(?:\s*\.\s*(\w+))?)?


### PR DESCRIPTION
Allows to handle correctly 'constructive' struct modifier used by Lineage 2 developers.
<img width="465" height="768" alt="image" src="https://github.com/user-attachments/assets/a67c3fa6-10b0-408d-8172-7bed5ed4f4f8" />